### PR TITLE
🚑 fix: change network, add goerli testnet

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,13 +1,6 @@
-import esbuild from 'esbuild';
+import esbuild from 'esbuild'
 // Automatically exclude all node_modules from the bundled version
-import { nodeExternalsPlugin } from 'esbuild-node-externals';
-import path from 'path';
-
-function tsPathResolver(content) {
-  const relativePath = path.relative(path.dirname(this.resourcePath), path.resolve(__dirname, '../src'));
-
-  return content.replaceAll(`from "@/`, `from "${relativePath ? relativePath + '/' : './'}`);
-}
+import { nodeExternalsPlugin } from 'esbuild-node-externals'
 
 esbuild
   .build({
@@ -30,9 +23,9 @@ esbuild
     splitting: true,
     format: 'esm',
     inject: ['esbuild.shim.js'],
-    plugins: [nodeExternalsPlugin()],
+    plugins: [nodeExternalsPlugin()]
   })
   .catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+    console.error(err)
+    process.exit(1)
+  })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viaprotocol/web3-wallets",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": false,
   "description": "Universal interface for web3 wallets",
   "author": "Via Protocol (https://via.exchange)",

--- a/src/context/WalletProvider.tsx
+++ b/src/context/WalletProvider.tsx
@@ -367,7 +367,6 @@ const WalletProvider = function WalletProvider({ children }: { children: React.R
       return false
     }
     const newChainIdHex = params[0].chainId
-    setState(prev => ({ ...prev, status: WalletStatusEnum.LOADING }))
 
     try {
       await provider.send('wallet_switchEthereumChain', [
@@ -375,11 +374,9 @@ const WalletProvider = function WalletProvider({ children }: { children: React.R
           chainId: newChainIdHex
         }
       ])
-      setState(prev => ({ ...prev, status: WalletStatusEnum.READY }))
       return true
     } catch (error: any) {
       if (error.code === ERRCODE.UserRejected) {
-        setState(prev => ({ ...prev, status: WalletStatusEnum.READY }))
         console.warn('[Wallet] User rejected the request')
         return false
       }
@@ -389,11 +386,9 @@ const WalletProvider = function WalletProvider({ children }: { children: React.R
         try {
           console.log('[Wallet] Try to add the network...', params)
           await provider.send('wallet_addEthereumChain', params)
-          setState(prev => ({ ...prev, status: WalletStatusEnum.READY }))
           // todo: Users can allow adding, but not allowing switching
           return true
         } catch (addNetworkError: any) {
-          setState(prev => ({ ...prev, status: WalletStatusEnum.READY }))
           if (addNetworkError.code === ERRCODE.UserRejected) {
             console.warn('[Wallet] User rejected the request')
             return false

--- a/src/context/WalletProvider.tsx
+++ b/src/context/WalletProvider.tsx
@@ -51,20 +51,6 @@ const WalletProvider = function WalletProvider({ children }: { children: React.R
 
       let { chainId: walletChainId, address, addressShort, addressDomain } = await fetchEvmWalletInfo(provider)
 
-      const isNeedToChangeNetwork = chainId && walletChainId !== chainId
-
-      if (isNeedToChangeNetwork) {
-        const network = getNetworkById(chainId)
-        if (!network.data.params) {
-          setState(prev => ({ ...prev, status: WalletStatusEnum.NOT_INITED }))
-          throw new Error(`Missing network ${chainId} params`)
-        }
-        const isChanged = await evmChangeNetwork(network.data.params)
-        if (isChanged) {
-          walletChainId = network.chain_id
-        }
-      }
-
       walletProvider.on('chainChanged', evmChainChangeHandler as any)
       walletProvider.on('accountsChanged', evmAccountChangeHandler as any)
 
@@ -143,20 +129,6 @@ const WalletProvider = function WalletProvider({ children }: { children: React.R
     }
 
     let { chainId: walletChainId, address, addressShort, addressDomain } = await fetchEvmWalletInfo(provider)
-
-    const isNeedToChangeNetwork = chainId && walletChainId !== chainId
-
-    if (isNeedToChangeNetwork) {
-      const network = getNetworkById(chainId)
-      if (!network.data.params) {
-        setState(prev => ({ ...prev, status: WalletStatusEnum.NOT_INITED }))
-        throw new Error(`Missing network ${chainId} params`)
-      }
-      const isChanged = await evmChangeNetwork(network.data.params)
-      if (isChanged) {
-        walletChainId = network.chain_id
-      }
-    }
 
     walletProvider.on('chainChanged', evmChainChangeHandler as any)
     walletProvider.on('accountsChanged', evmAccountChangeHandler as any)

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -13,6 +13,18 @@ const networksRaw = [
     is_testnet: false
   },
   {
+    chain_id: 5,
+    name: 'Ethereum Goerli',
+    short_name: 'Ethereum',
+    logo_url: 'https://etherscan.io/images/ethereum-icon.png',
+    explorer_url: 'https://goerli.etherscan.io/',
+    rpc_url: 'https://rpc.ankr.com/eth_goerli',
+    currency_name: 'Ethereum',
+    currency_symbol: 'GoerliETH',
+    currency_decimals: 18,
+    is_testnet: true
+  },
+  {
     chain_id: 4,
     name: 'Rinkeby Testnet',
     short_name: 'Rinkeby Testnet',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { CoinbaseWalletProvider } from '@coinbase/wallet-sdk'
-import type { TransactionReceipt, TransactionRequest, Web3Provider } from '@ethersproject/providers'
+import type { TransactionRequest, Web3Provider } from '@ethersproject/providers'
 import type { MetaMaskInpageProvider } from '@metamask/providers'
 import type { Connection, Signer, Transaction } from '@solana/web3.js'
 import type WalletConnectProvider from '@walletconnect/web3-provider'


### PR DESCRIPTION
- Remove status changes when change network. We have asynchronous logic for which the state is not needed, as the wallet can be operated at this time
- Remove change network on `connect / restore` (It's infuriating 😡)
- Add Goerli testnet
- ESLint fix