### PR TITLE
✨ feat: Use permit2

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@solana/wallet-adapter-phantom": "^0.9.8",
     "@solana/web3.js": "^1.43.5",
     "@tanstack/react-query": "^4.1.3",
+    "@uniswap/permit2-sdk": "^1.2.0",
     "@walletconnect/web3-provider": "^1.7.8",
     "abitype": "^0.1.7",
     "ethers": "5.7.2",

--- a/src/hooks/usePermit/constants.ts
+++ b/src/hooks/usePermit/constants.ts
@@ -3,7 +3,7 @@ import { NETWORK_IDS } from '@/constants'
 
 const MAX_UINT256 = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 
-const EIP712Domains = {
+const EIP712PermitDomain = {
   [NETWORK_IDS.Ethereum]: [
     { name: 'name', type: 'string' },
     { name: 'version', type: 'string' },
@@ -17,6 +17,32 @@ const EIP712Domains = {
     { name: 'verifyingContract', type: 'address' }
   ]
 }
+
+const EIP712Permit2Domain = [
+  { name: 'name', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' }
+]
+
+const PermitSingleMessage = [
+  { name: 'owner', type: 'address' },
+  { name: 'spender', type: 'address' },
+  { name: 'value', type: 'uint256' },
+  { name: 'nonce', type: 'uint256' },
+  { name: 'deadline', type: 'uint256' }
+]
+
+const Permit2MessageDetails = [
+  { name: 'details', type: 'PermitDetails' },
+  { name: 'spender', type: 'address' },
+  { name: 'sigDeadline', type: 'uint256' }
+]
+
+const PermitSingle = [
+  { name: 'details', type: 'PermitDetails' },
+  { name: 'spender', type: 'address' },
+  { name: 'sigDeadline', type: 'uint256' }
+]
 
 const NONCES_FN = '0x7ecebe00'
 const NAME_FN = '0x06fdde03'
@@ -54,4 +80,4 @@ const SUPPORTED_TOKENS: TPermitTokens = {
   ERC2612: ERC2612_TOKENS
 }
 
-export { MAX_UINT256, EIP712Domains, NONCES_FN, NAME_FN, SUPPORTED_TOKENS, DAI_TOKENS, ERC2612_TOKENS }
+export { MAX_UINT256, EIP712PermitDomain, EIP712Permit2Domain, PermitMessage, NONCES_FN, NAME_FN, SUPPORTED_TOKENS, DAI_TOKENS, ERC2612_TOKENS }

--- a/src/hooks/usePermit/constants.ts
+++ b/src/hooks/usePermit/constants.ts
@@ -89,4 +89,4 @@ const SUPPORTED_TOKENS: TPermitTokens = {
   ERC2612: ERC2612_TOKENS
 }
 
-export { MAX_UINT256, EIP712PermitDomain, EIP712Permit2Domain, DaiPermitMessage, PermitMessage, PermitSingleMessage, PermitSingleDetails,  NONCES_FN, NAME_FN, SUPPORTED_TOKENS, DAI_TOKENS, ERC2612_TOKENS }
+export { MAX_UINT256, EIP712PermitDomain, EIP712Permit2Domain, DaiPermitMessage, PermitMessage, PermitSingleMessage, PermitSingleDetails, NONCES_FN, NAME_FN, SUPPORTED_TOKENS, DAI_TOKENS, ERC2612_TOKENS }

--- a/src/hooks/usePermit/constants.ts
+++ b/src/hooks/usePermit/constants.ts
@@ -3,7 +3,7 @@ import { NETWORK_IDS } from '@/constants'
 
 const MAX_UINT256 = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 
-const EIP712PermitDomain = {
+const EIP712PermitDomains = {
   [NETWORK_IDS.Ethereum]: [
     { name: 'name', type: 'string' },
     { name: 'version', type: 'string' },
@@ -89,4 +89,4 @@ const SUPPORTED_TOKENS: TPermitTokens = {
   ERC2612: ERC2612_TOKENS
 }
 
-export { MAX_UINT256, EIP712PermitDomain, EIP712Permit2Domain, DaiPermitMessage, PermitMessage, PermitSingleMessage, PermitSingleDetails, NONCES_FN, NAME_FN, SUPPORTED_TOKENS, DAI_TOKENS, ERC2612_TOKENS }
+export { MAX_UINT256, EIP712PermitDomains, EIP712Permit2Domain, DaiPermitMessage, PermitMessage, PermitSingleMessage, PermitSingleDetails, NONCES_FN, NAME_FN, SUPPORTED_TOKENS, DAI_TOKENS, ERC2612_TOKENS }

--- a/src/hooks/usePermit/constants.ts
+++ b/src/hooks/usePermit/constants.ts
@@ -24,7 +24,15 @@ const EIP712Permit2Domain = [
   { name: 'verifyingContract', type: 'address' }
 ]
 
-const PermitSingleMessage = [
+const DaiPermitMessage = [
+  { name: 'holder', type: 'address' },
+  { name: 'spender', type: 'address' },
+  { name: 'nonce', type: 'uint256' },
+  { name: 'expiry', type: 'uint256' },
+  { name: 'allowed', type: 'bool' }
+]
+
+const PermitMessage = [
   { name: 'owner', type: 'address' },
   { name: 'spender', type: 'address' },
   { name: 'value', type: 'uint256' },
@@ -32,16 +40,17 @@ const PermitSingleMessage = [
   { name: 'deadline', type: 'uint256' }
 ]
 
-const Permit2MessageDetails = [
+const PermitSingleMessage = [
   { name: 'details', type: 'PermitDetails' },
   { name: 'spender', type: 'address' },
   { name: 'sigDeadline', type: 'uint256' }
 ]
 
-const PermitSingle = [
-  { name: 'details', type: 'PermitDetails' },
-  { name: 'spender', type: 'address' },
-  { name: 'sigDeadline', type: 'uint256' }
+const PermitSingleDetails = [
+  { name: 'token', type: 'address' },
+  { name: 'amount', type: 'uint160' },
+  { name: 'expiration', type: 'uint48' },
+  { name: 'nonce', type: 'uint48' }
 ]
 
 const NONCES_FN = '0x7ecebe00'
@@ -80,4 +89,4 @@ const SUPPORTED_TOKENS: TPermitTokens = {
   ERC2612: ERC2612_TOKENS
 }
 
-export { MAX_UINT256, EIP712PermitDomain, EIP712Permit2Domain, PermitMessage, NONCES_FN, NAME_FN, SUPPORTED_TOKENS, DAI_TOKENS, ERC2612_TOKENS }
+export { MAX_UINT256, EIP712PermitDomain, EIP712Permit2Domain, DaiPermitMessage, PermitMessage, PermitSingleMessage, PermitSingleDetails,  NONCES_FN, NAME_FN, SUPPORTED_TOKENS, DAI_TOKENS, ERC2612_TOKENS }

--- a/src/hooks/usePermit/types.ts
+++ b/src/hooks/usePermit/types.ts
@@ -8,7 +8,7 @@ type TDaiPermitMessage = {
   allowed?: boolean
 }
 
-type TERC2612PermitMessage = {
+type TPermitMessage = {
   owner: string
   spender: string
   value: number | string
@@ -16,13 +16,13 @@ type TERC2612PermitMessage = {
   deadline: number | string
 }
 
-type TPermit2Message = {
-  details: TPermit2Detail
+type TPermitSingleMessage = {
+  details: TPermitSingleDetails
   spender: string
   sigDeadline: number | string
 }
 
-type TPermit2Detail = {
+type TPermitSingleDetails = {
   token: string,
   amount: number | string
   expiration: number | string
@@ -75,4 +75,4 @@ type TPermitTokens = {
   [key in TPermitTypes]: TPermitToken[]
 }
 
-export type { TDaiPermitMessage, TPermitToken, TERC2612PermitMessage, TPermitDomain, TPermit2Domain, TRSVResponse, TUsePermitOptions, TPermitTypes, TPermitTokens }
+export type { TDaiPermitMessage, TPermitToken, TPermitMessage, TPermitSingleMessage, TPermitSingleDetails, TPermitDomain, TPermit2Domain, TRSVResponse, TUsePermitOptions, TPermitTypes, TPermitTokens }

--- a/src/hooks/usePermit/types.ts
+++ b/src/hooks/usePermit/types.ts
@@ -23,7 +23,7 @@ type TPermitSingleMessage = {
 }
 
 type TPermitSingleDetails = {
-  token: string,
+  token: string
   amount: number | string
   expiration: number | string
   nonce: number | string

--- a/src/hooks/usePermit/types.ts
+++ b/src/hooks/usePermit/types.ts
@@ -16,11 +16,30 @@ type TERC2612PermitMessage = {
   deadline: number | string
 }
 
-type TDomain = {
+type TPermit2Message = {
+  details: TPermit2Detail
+  spender: string
+  sigDeadline: number | string
+}
+
+type TPermit2Detail = {
+  token: string,
+  amount: number | string
+  expiration: number | string
+  nonce: number | string
+}
+
+type TPermitDomain = {
   name: string
   version: string
   chainId?: number
   salt?: string
+  verifyingContract: string
+}
+
+type TPermit2Domain = {
+  name: string
+  chainId: number
   verifyingContract: string
 }
 
@@ -56,4 +75,4 @@ type TPermitTokens = {
   [key in TPermitTypes]: TPermitToken[]
 }
 
-export type { TDaiPermitMessage, TPermitToken, TERC2612PermitMessage, TDomain, TRSVResponse, TUsePermitOptions, TPermitTypes, TPermitTokens }
+export type { TDaiPermitMessage, TPermitToken, TERC2612PermitMessage, TPermitDomain, TPermit2Domain, TRSVResponse, TUsePermitOptions, TPermitTypes, TPermitTokens }

--- a/src/hooks/usePermit/usePermit.ts
+++ b/src/hooks/usePermit/usePermit.ts
@@ -18,7 +18,7 @@ const usePermit = (options: TUsePermitOptions) => {
 
   const getTypedData = useCallback(async () => {
     const permitNonce = await getPermitNonce(provider, permitToken!)
-    const domain = getPermitDomain(provider, permitToken!)
+    const domain = await getPermitDomain(permitToken!)
 
     switch (getTokenKey(permitToken!)) {
       case 'DAI': {
@@ -28,7 +28,7 @@ const usePermit = (options: TUsePermitOptions) => {
           nonce: permitNonce,
           expiry: deadline || MAX_UINT256,
           allowed: true
-      	}
+        }
         return createTypedDaiData(message, domain, chainId)
       }
       case 'ERC2612': {

--- a/src/hooks/usePermit/usePermit.ts
+++ b/src/hooks/usePermit/usePermit.ts
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react'
 import { MAX_UINT256, SUPPORTED_TOKENS } from './constants'
 import { signData } from './rpc'
 import type { TDaiPermitMessage, TERC2612PermitMessage, TUsePermitOptions } from './types'
-import { createTypedDaiData, createTypedERC2612Data, getDomain, getPermitNonce, getTokenKey } from './utils'
+import { createTypedDaiData, createTypedPermitData, getPermitDomain, getPermitNonce, getTokenKey } from './utils'
 
 const usePermit = (options: TUsePermitOptions) => {
   const { provider, token, spender, owner, chainId, deadline } = options
@@ -18,7 +18,7 @@ const usePermit = (options: TUsePermitOptions) => {
 
   const getTypedData = useCallback(async () => {
     const permitNonce = await getPermitNonce(provider, permitToken!)
-    const domain = getDomain(permitToken!)
+    const domain = getPermitDomain(provider, permitToken!)
 
     switch (getTokenKey(permitToken!)) {
       case 'DAI': {
@@ -28,7 +28,7 @@ const usePermit = (options: TUsePermitOptions) => {
           nonce: permitNonce,
           expiry: deadline || MAX_UINT256,
           allowed: true
-        }
+      	}
         return createTypedDaiData(message, domain, chainId)
       }
       case 'ERC2612': {
@@ -39,7 +39,7 @@ const usePermit = (options: TUsePermitOptions) => {
           nonce: permitNonce,
           deadline: deadline || MAX_UINT256
         }
-        return createTypedERC2612Data(message, domain, chainId)
+        return createTypedPermitData(message, domain, chainId)
       }
       default:
         throw new Error('Token not supported')

--- a/src/hooks/usePermit/usePermit.ts
+++ b/src/hooks/usePermit/usePermit.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 
 import { MAX_UINT256, SUPPORTED_TOKENS } from './constants'
 import { signData } from './rpc'
-import type { TDaiPermitMessage, TERC2612PermitMessage, TUsePermitOptions } from './types'
+import type { TDaiPermitMessage, TPermitMessage, TUsePermitOptions } from './types'
 import { createTypedDaiData, createTypedPermitData, getPermitDomain, getPermitNonce, getTokenKey } from './utils'
 
 const usePermit = (options: TUsePermitOptions) => {
@@ -32,7 +32,7 @@ const usePermit = (options: TUsePermitOptions) => {
         return createTypedDaiData(message, domain, chainId)
       }
       case 'ERC2612': {
-        const message: TERC2612PermitMessage = {
+        const message: TPermitMessage = {
           owner,
           spender,
           value: MAX_UINT256,

--- a/src/hooks/usePermit/usePermit2.ts
+++ b/src/hooks/usePermit/usePermit2.ts
@@ -2,34 +2,29 @@ import { useCallback } from 'react'
 
 import { MAX_UINT256 } from './constants'
 import { signData } from './rpc'
-import type { TPermitSingleMessage, TPermitSingleDetails, TUsePermitOptions, TPermitToken } from './types'
-import { createTypedPermitSingleData, getPermit2Domain, getPermitNonce } from './utils'
+import type { TPermitSingleDetails, TPermitSingleMessage, TUsePermitOptions } from './types'
+import { createTypedPermitSingleData, getPermit2Domain, getPermit2Nonce } from './utils'
 
 const usePermit2 = (options: TUsePermitOptions) => {
   const { provider, token, spender, owner, chainId, deadline } = options
-
-  const permitToken: TPermitToken = {
-    address: token,
-    chainId: chainId
-  }
 
   const getSinglePermitTypedData = useCallback(async () => {
     const details: TPermitSingleDetails = {
       token,
       amount: MAX_UINT256,
       expiration: deadline || MAX_UINT256,
-      nonce: await getPermitNonce(provider, permitToken),
+      nonce: await getPermit2Nonce(provider, owner, token, spender)
     }
 
     const message: TPermitSingleMessage = {
-        details,
-        spender,
-        sigDeadline: deadline || MAX_UINT256
+      details,
+      spender,
+      sigDeadline: deadline || MAX_UINT256
     }
 
-    const domain = await getPermit2Domain(provider, permitToken!)
+    const domain = await getPermit2Domain(chainId)
     return createTypedPermitSingleData(message, domain)
-  }, [provider, permitToken, spender, owner, deadline])
+  }, [provider, spender, deadline])
 
   const permit = useCallback(async () => {
     const typedData = await getSinglePermitTypedData()

--- a/src/hooks/usePermit/usePermit2.ts
+++ b/src/hooks/usePermit/usePermit2.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { MAX_UINT256 } from './constants'
 import { signData } from './rpc'
-import type { TPermitSingleDetails, TPermitSingleMessage, TUsePermitOptions } from './types'
+import type { TPermitSingleDetails, TPermitSingleMessage, TPermitToken, TUsePermitOptions } from './types'
 import { createTypedPermitSingleData, getPermit2Domain, getPermit2Nonce } from './utils'
 
 const usePermit2 = (options: TUsePermitOptions) => {
@@ -22,7 +22,13 @@ const usePermit2 = (options: TUsePermitOptions) => {
       sigDeadline: deadline || MAX_UINT256
     }
 
-    const domain = await getPermit2Domain(chainId)
+    const permitToken: TPermitToken = {
+      address: token,
+      chainId,
+      name: 'Permit2'
+    }
+
+    const domain = await getPermit2Domain(permitToken)
     return createTypedPermitSingleData(message, domain)
   }, [provider, spender, deadline])
 

--- a/src/hooks/usePermit/usePermit2.ts
+++ b/src/hooks/usePermit/usePermit2.ts
@@ -1,0 +1,52 @@
+import { useCallback, useMemo } from 'react'
+
+import { MAX_UINT256, SUPPORTED_TOKENS } from './constants'
+import { signData } from './rpc'
+import type { TDaiPermitMessage, TERC2612PermitMessage, TUsePermitOptions, TPermitToken, TPermit2Message } from './types'
+import { createTypedDaiData, createTypedERC2612Data, getPermit2Domain, getPermitNonce, getTokenKey } from './utils'
+
+const usePermit2 = (options: TUsePermitOptions) => {
+  const { provider, token, spender, owner, chainId, deadline } = options
+
+  const permitToken: TPermitToken = {
+    address: token,
+    chainId: chainId
+  }
+
+  const getPermit = useCallback(async () => {
+    const message: TPermit2Message = {
+        details: {
+            token,
+            amount: MAX_UINT256,
+            expiration: deadline || MAX_UINT256,
+            nonce: await getPermitNonce(provider, permitToken),
+        },
+        spender,
+        sigDeadline: deadline || MAX_UINT256
+    }
+
+    const domain = await getPermit2Domain(provider, permitToken!)
+    return createTypedERC2612Data(message, domain)
+  }, [provider, permitToken, spender, owner, deadline])
+
+  const getTypedData = useCallback(async () => {
+    switch (getTokenKey(permitToken!)) {
+      case 'DAI':
+        return getDaiPermit()
+      case 'ERC2612':
+        return getERC2612Permit()
+      default:
+        throw new Error('Token not supported')
+    }
+  }, [token, chainId, getDaiPermit, getERC2612Permit])
+
+  const permit = useCallback(async () => {
+    const typedData = await getTypedData()
+
+    return signData(provider, owner, typedData)
+  }, [getTypedData, signData, provider, owner])
+
+  return { permit, isSupportedToken: !!permitToken }
+}
+
+export { usePermit }

--- a/src/hooks/usePermit/utils.ts
+++ b/src/hooks/usePermit/utils.ts
@@ -32,7 +32,7 @@ const getPermitDomain = async (provider: any, permitToken: TPermitToken): Promis
 
 const getPermit2Domain = async (permitToken: TPermitToken): Promise<TPermit2Domain> => {
   const { address, chainId } = permitToken
-  const domain: TPermit2Domain = { name: "Permit2", chainId, verifyingContract: address }
+  const domain: TPermit2Domain = { name: 'Permit2', chainId, verifyingContract: address }
   return domain
 }
 
@@ -101,6 +101,12 @@ const getPermitNonce = async (provider: Web3Provider, token: TPermitToken): Prom
   const { address, noncesFn = NONCES_FN } = token
 
   return call(provider, address, `${noncesFn}${addZeros(24)}${owner.slice(2)}`)
+}
+
+const getPermit2Nonce = async (provider: Web3Provider, owner: string, token: string, spender: string): Promise<number> => {
+  const allowanceProvider = new AllowanceProvider(provider, PERMIT2_ADDRESS)
+  const allowance: AllowanceData = await allowanceProvider?.getAllowanceData(token, owner, spender)
+  return allowance?.nonce
 }
 
 const getTokenKey = (token: TPermitToken) => {

--- a/src/hooks/usePermit/utils.ts
+++ b/src/hooks/usePermit/utils.ts
@@ -1,41 +1,38 @@
 import type { Web3Provider } from '@ethersproject/providers'
+import type { AllowanceData } from '@uniswap/permit2-sdk'
+import { AllowanceProvider, PERMIT2_ADDRESS } from '@uniswap/permit2-sdk'
 import { BigNumber } from 'ethers/lib/ethers'
 import { hexZeroPad } from 'ethers/lib/utils'
-import { EIP712Domains, NONCES_FN, SUPPORTED_TOKENS } from './constants'
+import { DaiPermitMessage, EIP712Permit2Domain, EIP712PermitDomains, NONCES_FN, PermitMessage, PermitSingleDetails, PermitSingleMessage, SUPPORTED_TOKENS } from './constants'
 import { call } from './rpc'
-import type { TDaiPermitMessage, TPermitDomain, TPermit2Domain, TERC2612PermitMessage, TPermitToken, TPermitTypes } from './types'
+import type { TDaiPermitMessage, TPermit2Domain, TPermitDomain, TPermitMessage, TPermitSingleMessage, TPermitToken, TPermitTypes } from './types'
 import { NETWORK_IDS } from '@/constants'
 
 const addZeros = (numZeros: number) => ''.padEnd(numZeros, '0')
 
-const getTokenName = async (provider: any, address: string) =>
-  hexToUtf8((await call(provider, address, NAME_FN)).substr(130))
-
-const getPermitDomain = async (provider: any, permitToken: TPermitToken): Promise<TPermitDomain> => {
+const getPermitDomain = async (permitToken: TPermitToken): Promise<TPermitDomain> => {
   const { address, chainId, name, version } = permitToken
-  const name = await getTokenName(provider, address)
-  
-  const domain: TPermitDomain = { 
+
+  const domain: TPermitDomain = {
     name,
     version: version || '1',
     verifyingContract: address
   }
-  
+
   if (chainId === NETWORK_IDS.Ethereum) {
     domain.chainId = chainId
   } else {
     domain.salt = hexZeroPad(BigNumber.from(chainId).toHexString(), 32)
   }
-  
+
   return domain
 }
 
 const getPermit2Domain = async (permitToken: TPermitToken): Promise<TPermit2Domain> => {
-  const { address, chainId } = permitToken
-  const domain: TPermit2Domain = { name: 'Permit2', chainId, verifyingContract: address }
+  const { address, chainId, name } = permitToken
+  const domain: TPermit2Domain = { name, chainId, verifyingContract: address }
   return domain
 }
-
 
 const createTypedDaiData = (message: TDaiPermitMessage, domain: TPermitDomain, chainId: number) => {
   if (!Object.keys(EIP712PermitDomains).includes(chainId.toString())) {
@@ -74,8 +71,6 @@ const createTypedPermitData = (message: TPermitMessage, domain: TPermitDomain, c
 
   return typedData
 }
-
-
 
 const createTypedPermitSingleData = (message: TPermitSingleMessage, domain: TPermit2Domain) => {
   const typedData = {
@@ -118,4 +113,4 @@ const getTokenKey = (token: TPermitToken) => {
   return entry[0] as TPermitTypes
 }
 
-export { addZeros, getTokenName, getPermitDomain, getPermit2Domain, createTypedDaiData, createTypedPermitData, createTypedPermit2Data, isTokenExists, getPermitNonce, getTokenKey }
+export { addZeros, getPermitDomain, getPermit2Domain, createTypedDaiData, createTypedPermitData, createTypedPermitSingleData, getPermit2Nonce, isTokenExists, getPermitNonce, getTokenKey }

--- a/src/hooks/usePermit/utils.ts
+++ b/src/hooks/usePermit/utils.ts
@@ -32,38 +32,13 @@ const getPermitDomain = async (provider: any, permitToken: TPermitToken): Promis
 
 const getPermit2Domain = async (permitToken: TPermitToken): Promise<TPermit2Domain> => {
   const { address, chainId } = permitToken
-  const domain: TPermitDomain = { name: "Permit2", chainId, verifyingContract: address }
+  const domain: TPermit2Domain = { name: "Permit2", chainId, verifyingContract: address }
   return domain
 }
 
 
-const createTypedDaiData = (message: TDaiPermitMessage, domain: TDomain, chainId: number) => {
-  if (!Object.keys(EIP712Domains).includes(chainId.toString())) {
-    throw new Error('ChainId not supported')
-  }
-
-  const typedData = {
-    types: {
-      // @ts-expect-error – Check type above
-      EIP712Domain: EIP712Domains[chainId]!,
-      Permit: [
-        { name: 'holder', type: 'address' },
-        { name: 'spender', type: 'address' },
-        { name: 'nonce', type: 'uint256' },
-        { name: 'expiry', type: 'uint256' },
-        { name: 'allowed', type: 'bool' }
-      ]
-    },
-    primaryType: 'Permit',
-    domain,
-    message
-  }
-
-  return typedData
-}
-
-const createTypedPermitData = (message: TERC2612PermitMessage, domain: TPermitDomain, chainId: number) => {
-  if (!Object.keys(EIP712Domains).includes(chainId.toString())) {
+const createTypedDaiData = (message: TDaiPermitMessage, domain: TPermitDomain, chainId: number) => {
+  if (!Object.keys(EIP712PermitDomains).includes(chainId.toString())) {
     throw new Error('ChainId not supported')
   }
 
@@ -71,13 +46,7 @@ const createTypedPermitData = (message: TERC2612PermitMessage, domain: TPermitDo
     types: {
       // @ts-expect-error – Check type above
       EIP712Domain: EIP712PermitDomains[chainId]!,
-      Permit: [
-        { name: 'owner', type: 'address' },
-        { name: 'spender', type: 'address' },
-        { name: 'value', type: 'uint256' },
-        { name: 'nonce', type: 'uint256' },
-        { name: 'deadline', type: 'uint256' }
-      ]
+      Permit: DaiPermitMessage
     },
     primaryType: 'Permit',
     domain,
@@ -87,19 +56,35 @@ const createTypedPermitData = (message: TERC2612PermitMessage, domain: TPermitDo
   return typedData
 }
 
-const createTypedPermit2Data = (message: TERC2612PermitMessage, domain: TPermit2Domain) => {
+const createTypedPermitData = (message: TPermitMessage, domain: TPermitDomain, chainId: number) => {
+  if (!Object.keys(EIP712PermitDomains).includes(chainId.toString())) {
+    throw new Error('ChainId not supported')
+  }
+
+  const typedData = {
+    types: {
+      // @ts-expect-error – Check type above
+      EIP712Domain: EIP712PermitDomains[chainId]!,
+      Permit: PermitMessage
+    },
+    primaryType: 'Permit',
+    domain,
+    message
+  }
+
+  return typedData
+}
+
+
+
+const createTypedPermitSingleData = (message: TPermitSingleMessage, domain: TPermit2Domain) => {
   const typedData = {
     types: {
       EIP712Domain: EIP712Permit2Domain,
-      PermitSingle,
-      PermitDetails: [
-          { name: 'token', type: 'address' },
-          { name: 'amount', type: 'uint160' },
-          { name: 'expiration', type: 'uint48' },
-          { name: 'nonce', type: 'uint48' }
-      ]
+      PermitSingle: PermitSingleMessage,
+      PermitDetails: PermitSingleDetails
     },
-    primaryType: 'Permit',
+    primaryType: 'Permit2',
     domain,
     message
   }


### PR DESCRIPTION
Added the new Uniswap's Permit2 support.

[More about Permit2](https://docs.uniswap.org/protocol/permit2/overview)
Briefly, it allows to use nice-looking EIP2612 signature for tokens that not have Permit logic implemented in their smart-contracts, by providing permission for spending directly to Uniswap's Permit2 smart-contract.

Right now I added the logic for permitting only one asset (Single Permit), however the Permit2 has so many other cool features, they could be easily added to the code I wrote.

I also installed the [@uniswap/permit2-sdk](https://www.npmjs.com/package/@uniswap/permit2-sdk) to simplify contract interaction. If you decide to add other features from Permit2, this library could be really handy. 😇